### PR TITLE
[v0.1] Improve error message box

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -259,7 +259,7 @@ body {
     pre {
       text-align: left;
       overflow: auto;
-      max-height: 70vh;
+      max-height: 40vh;
     }
   }
   .hint {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -29,30 +29,24 @@ function notifyError(msg: string, err?: unknown) {
   if (!(err instanceof Error)) {
     throw err;
   }
-  if (err?.stack)
-    SwalReact.fire({
-      showClass: { popup: "" },
-      hideClass: { popup: "" },
-      icon: "error",
-      title: "錯誤",
-      customClass: "error-with-stack" as any,
-      html: (
-        <>
-          <p>{msg}</p>
-          <pre lang="en-x-code">{err.stack.replace(/\n +at eval[^]+/, "")}</pre>
-        </>
-      ),
-      confirmButtonText: "確定",
-    });
-  else
-    Swal.fire({
-      showClass: { popup: "" },
-      hideClass: { popup: "" },
-      icon: "error",
-      title: "錯誤",
-      text: msg,
-      confirmButtonText: "確定",
-    });
+  let technicalMessage = err.message;
+  if (err?.stack) {
+    technicalMessage += "\n" + err.stack.replace(/\n +at eval[^]+/, "");
+  }
+  SwalReact.fire({
+    showClass: { popup: "" },
+    hideClass: { popup: "" },
+    icon: "error",
+    title: "錯誤",
+    customClass: "error-with-stack",
+    html: (
+      <>
+        <p>{msg}</p>
+        <pre lang="en-x-code">{technicalMessage}</pre>
+      </>
+    ),
+    confirmButtonText: "確定",
+  });
 }
 
 function copyFailed() {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -25,15 +25,22 @@ function get代表字(地位: class音韻地位): string[] {
 
 const SwalReact = withReactContent(Swal);
 
-function notifyError(msg: string, err?: unknown) {
-  if (!(err instanceof Error)) {
-    throw err;
+function notifyError(msg: string, err?: any) {
+  let technicalMessage: string | null = null;
+  if (err !== undefined) {
+    if (!(err instanceof Error)) {
+      throw err;
+    }
+    technicalMessage = err.message;
+    while (err.cause instanceof Error) {
+      err = err.cause;
+      technicalMessage += "\n" + err.message;
+    }
+    if (err?.stack) {
+      technicalMessage += "\n" + err.stack.replace(/\n +at eval[^]+/, "");
+    }
   }
-  let technicalMessage = err.message;
-  if (err?.stack) {
-    technicalMessage += "\n" + err.stack.replace(/\n +at eval[^]+/, "");
-  }
-  SwalReact.fire({
+  const config: Parameters<typeof SwalReact.fire>[0] = {
     showClass: { popup: "" },
     hideClass: { popup: "" },
     icon: "error",
@@ -46,7 +53,19 @@ function notifyError(msg: string, err?: unknown) {
       </>
     ),
     confirmButtonText: "確定",
-  });
+  };
+  if (technicalMessage !== null) {
+    config.html = (
+      <>
+        <p>{msg}</p>
+        <pre lang="en-x-code">{technicalMessage}</pre>
+      </>
+    );
+    config.customClass = "error-with-stack";
+  } else {
+    config.text = msg;
+  }
+  SwalReact.fire(config);
 }
 
 function copyFailed() {


### PR DESCRIPTION
Now it contains:

- The error's `.message` (which is MUCH more useful than the stack trace :joy:
- `.message` from the error's cause chain (utilized by `tshet-uinh-deriver-tools`)
- Stack trace (of the last error in the chain, if any)
